### PR TITLE
Returns 404 when token in invitation is invalid

### DIFF
--- a/app/controllers/concerns/rails_jwt_auth/render_helper.rb
+++ b/app/controllers/concerns/rails_jwt_auth/render_helper.rb
@@ -13,6 +13,10 @@ module RailsJwtAuth
       render json: {}, status: 204
     end
 
+    def render_404
+      render json: {}, status: 404
+    end
+
     def render_422(errors)
       render json: {errors: errors}, status: 422
     end

--- a/app/controllers/rails_jwt_auth/invitations_controller.rb
+++ b/app/controllers/rails_jwt_auth/invitations_controller.rb
@@ -12,6 +12,9 @@ module RailsJwtAuth
     def update
       attr_hash = invitation_update_params
       user = RailsJwtAuth.model.where(invitation_token: params[:id]).first
+
+      return render_404 if user.blank?
+
       user.assign_attributes attr_hash
       user.accept_invitation!
 

--- a/spec/controllers/invitations_controller_spec.rb
+++ b/spec/controllers/invitations_controller_spec.rb
@@ -68,6 +68,19 @@ RSpec.describe RailsJwtAuth::InvitationsController do
             end
           end
 
+          context 'with invalid token' do
+            before do
+              put :update, params: {
+                id: 'invalid_token',
+                invitation: {password: 'abcdef', password_confirmation: 'abcdef'}
+              }
+            end
+
+            it 'returns HTTP 404' do
+              expect(response).to have_http_status(404)
+            end
+          end
+
           context 'with invitation token' do
             before do
               put :update, params: {


### PR DESCRIPTION
When a invalid invitable token is provided, it returned 500 since it is not able to call `assign_attributes`. Now, it returns 404.