### PR TITLE
Already confirmed

### DIFF
--- a/app/models/concerns/rails_jwt_auth/invitable.rb
+++ b/app/models/concerns/rails_jwt_auth/invitable.rb
@@ -55,7 +55,7 @@ module RailsJwtAuth
 
       if valid_invitation?
         accept_invitation
-        self.confirmed_at = Time.now.utc if respond_to? :confirmed_at
+        self.confirmed_at = Time.now.utc if respond_to?(:confirmed_at) && confirmed_at.nil?
       else
         errors.add(:invitation_token, :invalid)
       end

--- a/spec/models/concerns/invitable_spec.rb
+++ b/spec/models/concerns/invitable_spec.rb
@@ -155,6 +155,19 @@ describe RailsJwtAuth::Invitable do
             expect(user.reload.invitation_accepted_at).to be_nil
           end
         end
+
+        context 'with already confirmed user' do
+          before do
+            @invited_user = "#{orm}User".constantize.invite! email: 'valid@example.com'
+            @invited_user.confirm!
+            @invited_user.accept_invitation!
+            @invited_user.save
+          end
+
+          it 'doesn\'t include already_confirmed in errors' do
+            expect(@invited_user.errors).to be_empty
+          end
+        end
       end
 
       describe '#invite!' do


### PR DESCRIPTION
Steps to reproduce the problem:

1. Invite new user.
2. Confirm this very same user.
3. Accept the invitation of the user. It adds an error saying that the user is already_confirmed and it cannot be saved (thus the invitation is not accepted).