### PR TITLE
Recoverable should be reseted when password is updated

### DIFF
--- a/app/models/concerns/rails_jwt_auth/authenticatable.rb
+++ b/app/models/concerns/rails_jwt_auth/authenticatable.rb
@@ -50,6 +50,8 @@ module RailsJwtAuth
         errors.add(:password, 'blank')
       end
 
+      params.merge!(reset_password_token: nil, reset_password_sent_at: nil) if reset_password_token
+
       errors.empty? ? update_attributes(params) : false
     end
 


### PR DESCRIPTION
When both Recoverable and Authenticable are used together, password cannot be updated in any way if a process of recoverable is in process.
BTW I think that is good practice to reset reset_password_token when the password is updated by the user.