### PR TITLE
Omniauth module

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,4 +12,5 @@ gem 'sqlite3'
 
 group :development, :test do
   gem 'pry-rails'
+  gem 'omniauth'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,19 +78,20 @@ GEM
     erubi (1.10.0)
     factory_bot (6.2.0)
       activesupport (>= 5.0.0)
-    globalid (0.5.2)
+    globalid (1.0.0)
       activesupport (>= 5.0)
+    hashie (5.0.0)
     i18n (1.8.10)
       concurrent-ruby (~> 1.0)
-    jwt (2.2.3)
+    jwt (2.3.0)
     loofah (2.12.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mail (2.7.1)
       mini_mime (>= 0.1.1)
-    marcel (1.0.1)
+    marcel (1.0.2)
     method_source (1.0.0)
-    mini_mime (1.1.1)
+    mini_mime (1.1.2)
     mini_portile2 (2.6.1)
     minitest (5.14.4)
     mongo (2.14.0)
@@ -102,6 +103,10 @@ GEM
     nokogiri (1.12.3)
       mini_portile2 (~> 2.6.1)
       racc (~> 1.4)
+    omniauth (2.0.4)
+      hashie (>= 3.4.6)
+      rack (>= 1.6.2, < 3)
+      rack-protection
     pry (0.14.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -109,6 +114,8 @@ GEM
       pry (>= 0.10.4)
     racc (1.5.2)
     rack (2.2.3)
+    rack-protection (2.1.0)
+      rack
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rails (6.1.4.1)
@@ -158,9 +165,9 @@ GEM
     sprockets (4.0.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
-    sprockets-rails (3.2.2)
-      actionpack (>= 4.0)
-      activesupport (>= 4.0)
+    sprockets-rails (3.4.2)
+      actionpack (>= 5.2)
+      activesupport (>= 5.2)
       sprockets (>= 3.0.0)
     sqlite3 (1.4.2)
     thor (1.1.0)
@@ -177,6 +184,7 @@ PLATFORMS
 DEPENDENCIES
   factory_bot
   mongoid
+  omniauth
   pry-rails
   rails_jwt_auth!
   rspec-rails

--- a/app/controllers/rails_jwt_auth/omniauths_controller.rb
+++ b/app/controllers/rails_jwt_auth/omniauths_controller.rb
@@ -1,0 +1,22 @@
+module RailsJwtAuth
+  class OmniauthsController < ApplicationController
+    include RenderHelper
+
+    def callback
+      user = RailsJwtAuth.model_name.constantize.from_omniauth(auth_hash)
+      se = RailsJwtAuth::OmniauthSession.new(user)
+
+      if se.generate!
+        render_session se.jwt, se.user
+      else
+        render_422 se.errors.details
+      end
+    end
+
+    protected
+
+    def auth_hash
+      request.env['omniauth.auth']
+    end
+  end
+end

--- a/app/models/concerns/rails_jwt_auth/omniauthable.rb
+++ b/app/models/concerns/rails_jwt_auth/omniauthable.rb
@@ -1,0 +1,20 @@
+module RailsJwtAuth
+  module Omniauthable
+    class NotImplementedMethod < StandardError; end
+
+    def self.included(klass)
+      klass.extend(ClassMethods)
+    end
+
+    module ClassMethods
+      def from_omniauth(_auth)
+        raise NotImplementedMethod.new(
+          I18n.t(
+            'rails_jwt_auth.models.omniauthable.from_omniauth.not_implemented',
+            model:RailsJwtAuth.model
+          )
+        )
+      end
+    end
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -13,3 +13,7 @@ en:
         subject: "Password changed"
       unlock_instructions:
         subject: "Unlock instructions"
+    models:
+      omniauthable:
+        from_omniauth:
+          not_implemented: "You must implement 'self.from_omniauth' in your '%{model}' model"

--- a/lib/generators/rails_jwt_auth/install_generator.rb
+++ b/lib/generators/rails_jwt_auth/install_generator.rb
@@ -21,5 +21,6 @@ class RailsJwtAuth::InstallGenerator < Rails::Generators::Base
     route "resources :reset_passwords, controller: 'rails_jwt_auth/reset_passwords', only: [:show, :create, :update]"
     route "resources :invitations, controller: 'rails_jwt_auth/invitations', only: [:show, :create, :update]"
     route "resources :unlock_accounts, controller: 'rails_jwt_auth/unlock_accounts', only: %i[update]"
+    route "post '/auth/:provider/callback', to: 'rails_jwt_auth/omniauths#callback', as: 'oauth_callback'"
   end
 end

--- a/lib/generators/templates/initializer.rb
+++ b/lib/generators/templates/initializer.rb
@@ -76,4 +76,10 @@ RailsJwtAuth.setup do |config|
 
   # set false to avoid giving clue about the existing emails with errors
   # config.avoid_email_errors = true
+
+  # get omniauth from providers (Require external gems)
+  #config.omniauth :<provider>, ENV['<CLIENT_ID>'], ENV['<SECRET>'], {
+  #  provider_ignores_state: true, # Needed
+  #  scope: 'userinfo.email, userinfo.profile'
+  #}
 end

--- a/lib/rails_jwt_auth.rb
+++ b/lib/rails_jwt_auth.rb
@@ -3,7 +3,10 @@ require 'bcrypt'
 
 require 'rails_jwt_auth/engine'
 require 'rails_jwt_auth/jwt_manager'
+require 'rails_jwt_auth/omniauth_manager'
+require 'rails_jwt_auth/session_helper'
 require 'rails_jwt_auth/session'
+require 'rails_jwt_auth/omniauth_session'
 
 module RailsJwtAuth
   NotConfirmationsUrl = Class.new(StandardError)
@@ -90,6 +93,9 @@ module RailsJwtAuth
   mattr_accessor :avoid_email_errors
   self.avoid_email_errors = true
 
+  mattr_accessor :omniauth_configs
+  self.omniauth_configs = {}
+
   def self.setup
     yield self
   end
@@ -104,6 +110,10 @@ module RailsJwtAuth
 
   def self.table_name
     model_name.underscore.pluralize
+  end
+
+  def self.omniauth(provider, *args)
+    omniauth_configs[provider] = RailsJwtAuth::OmniauthManager.new(provider, args)
   end
 
   # Thanks to https://github.com/heartcombo/devise/blob/master/lib/devise.rb#L496

--- a/lib/rails_jwt_auth/engine.rb
+++ b/lib/rails_jwt_auth/engine.rb
@@ -1,4 +1,12 @@
 module RailsJwtAuth
   class Engine < ::Rails::Engine
+    initializer 'rails_jwt.omniauth', after: :load_config_initializers, before: :build_middleware_stack do |app|
+      app.middleware.use ActionDispatch::Session::CacheStore
+      RailsJwtAuth.omniauth_configs.each do |provider, config|
+        app.middleware.use config.strategy_class, *config.args do |strategy|
+          config.strategy = strategy
+        end
+      end
+    end
   end
 end

--- a/lib/rails_jwt_auth/omniauth_manager.rb
+++ b/lib/rails_jwt_auth/omniauth_manager.rb
@@ -1,0 +1,32 @@
+module RailsJwtAuth
+  class StrategyNotFound < NameError
+    def initialize(strategy)
+      @strategy = strategy
+      super("Could not find a strategy with name `#{strategy}'. " \
+        "Please ensure it is required or explicitly set it using the :strategy_class option.")
+    end
+  end
+
+  class OmniauthManager
+    # Based on https://github.com/heartcombo/devise Config
+
+    attr_accessor :strategy
+    attr_reader :args, :options, :provider, :strategy_name
+
+    def initialize(provider, args)
+      @provider = provider
+      @args = args
+      @options = @args.last.is_a?(Hash) ? @args.last : {}
+      @strategy = nil
+      @strategy_class = nil
+      @strategy_name  = options[:name] || @provider
+    end
+
+    def strategy_class
+      @strategy_class ||= ::OmniAuth.strategies.find do |strategy|
+        strategy.to_s =~ /#{::OmniAuth::Utils.camelize(strategy_name)}$/ ||
+          strategy.default_options[:name] == strategy_name
+      end
+    end
+  end
+end

--- a/lib/rails_jwt_auth/omniauth_session.rb
+++ b/lib/rails_jwt_auth/omniauth_session.rb
@@ -1,0 +1,51 @@
+module RailsJwtAuth
+  class OmniauthSession
+    include RailsJwtAuth::SessionHelper
+
+    attr_reader :user, :errors, :jwt
+
+    def initialize(user)
+      @user = user
+    end
+
+    def valid?
+      validate!
+
+      !errors?
+    end
+
+    def generate!
+      if valid?
+        @user.clean_reset_password if recoverable?
+        @user.clean_lock if lockable?
+        @user.load_auth_token
+
+        unless user.save
+          add_error(RailsJwtAuth.model_name.underscore, :invalid)
+
+          return false
+        end
+
+        generate_jwt(nil)
+
+        true
+      else
+        @user.failed_attempt if lockable?
+
+        false
+      end
+    end
+
+    private
+
+    def validate!
+      # Can't use ActiveModel::Validations since we have dynamic fields
+      @errors = Errors.new({})
+
+      validate_user
+      validate_user_is_confirmed if confirmable?
+      validate_user_is_not_locked if lockable?
+      validate_custom
+    end
+  end
+end

--- a/lib/rails_jwt_auth/session.rb
+++ b/lib/rails_jwt_auth/session.rb
@@ -1,8 +1,8 @@
 module RailsJwtAuth
   class Session
-    attr_reader :user, :errors, :jwt
+    include RailsJwtAuth::SessionHelper
 
-    Errors = Struct.new :details # simulate ActiveModel::Errors
+    attr_reader :user, :errors, :jwt
 
     def initialize(params={})
       @auth_field_value = (params[RailsJwtAuth.auth_field_name] || '').strip
@@ -54,75 +54,6 @@ module RailsJwtAuth
       validate_user_is_not_locked if lockable?
       validate_user_password unless errors?
       validate_custom
-    end
-
-    def find_user
-      @user = RailsJwtAuth.model.where(RailsJwtAuth.auth_field_name => @auth_field_value).first
-    end
-
-    def confirmable?
-      @user&.kind_of?(RailsJwtAuth::Confirmable)
-    end
-
-    def lockable?
-      @user&.kind_of?(RailsJwtAuth::Lockable)
-    end
-
-    def recoverable?
-      @user&.kind_of?(RailsJwtAuth::Recoverable)
-    end
-
-    def trackable?
-      @user&.kind_of?(RailsJwtAuth::Trackable)
-    end
-
-    def user?
-      @user.present?
-    end
-
-    def field_error(field)
-      RailsJwtAuth.avoid_email_errors ? :session : field
-    end
-
-    def validate_auth_field_presence
-      add_error(RailsJwtAuth.auth_field_name, :blank) if @auth_field_value.blank?
-    end
-
-    def validate_password_presence
-      add_error(:password, :blank) if @password.blank?
-    end
-
-    def validate_user_exist
-      add_error(field_error(RailsJwtAuth.auth_field_name), :invalid) unless @user
-    end
-
-    def validate_user_password
-      add_error(field_error(:password), :invalid) unless @user.authenticate(@password)
-    end
-
-    def validate_user_is_confirmed
-      add_error(RailsJwtAuth.email_field_name, :unconfirmed) unless @user.confirmed?
-    end
-
-    def validate_user_is_not_locked
-      add_error(RailsJwtAuth.email_field_name, :locked) if @user.access_locked?
-    end
-
-    def validate_custom
-      # allow add custom validations overwriting this method
-    end
-
-    def add_error(field, detail)
-      @errors.details[field.to_sym] ||= []
-      @errors.details[field.to_sym].push({error: detail})
-    end
-
-    def errors?
-      @errors.details.any?
-    end
-
-    def generate_jwt(request)
-      @jwt = JwtManager.encode(user.to_token_payload(request))
     end
   end
 end

--- a/lib/rails_jwt_auth/session_helper.rb
+++ b/lib/rails_jwt_auth/session_helper.rb
@@ -1,0 +1,80 @@
+module RailsJwtAuth
+	module SessionHelper
+    Errors = Struct.new :details # simulate ActiveModel::Errors
+
+		private
+
+		def find_user
+      @user = RailsJwtAuth.model.where(RailsJwtAuth.auth_field_name => @auth_field_value).first
+    end
+
+    def confirmable?
+      @user&.kind_of?(RailsJwtAuth::Confirmable)
+    end
+
+    def lockable?
+      @user&.kind_of?(RailsJwtAuth::Lockable)
+    end
+
+    def recoverable?
+      @user&.kind_of?(RailsJwtAuth::Recoverable)
+    end
+
+    def trackable?
+      @user&.kind_of?(RailsJwtAuth::Trackable)
+    end
+
+    def user?
+      @user.present?
+    end
+
+    def field_error(field)
+      RailsJwtAuth.avoid_email_errors ? :session : field
+    end
+
+		def validate_user
+      add_error(:session, :not_found) if @user.blank?
+		end
+
+    def validate_auth_field_presence
+      add_error(RailsJwtAuth.auth_field_name, :blank) if @auth_field_value.blank?
+    end
+
+    def validate_password_presence
+      add_error(:password, :blank) if @password.blank?
+    end
+
+    def validate_user_exist
+      add_error(field_error(RailsJwtAuth.auth_field_name), :invalid) unless @user
+    end
+
+    def validate_user_password
+      add_error(field_error(:password), :invalid) unless @user.authenticate(@password)
+    end
+
+    def validate_user_is_confirmed
+      add_error(RailsJwtAuth.email_field_name, :unconfirmed) unless @user.confirmed?
+    end
+
+    def validate_user_is_not_locked
+      add_error(RailsJwtAuth.email_field_name, :locked) if @user.access_locked?
+    end
+
+    def validate_custom
+      # allow add custom validations overwriting this method
+    end
+
+    def add_error(field, detail)
+      @errors.details[field.to_sym] ||= []
+      @errors.details[field.to_sym].push({error: detail})
+    end
+
+    def errors?
+      @errors.details.any?
+    end
+
+    def generate_jwt(request)
+      @jwt = JwtManager.encode(@user.to_token_payload(request))
+    end
+	end
+end

--- a/spec/controllers/omniauths_controller_spec.rb
+++ b/spec/controllers/omniauths_controller_spec.rb
@@ -1,0 +1,93 @@
+require 'rails_helper'
+require 'rails_jwt_auth/jwt_manager'
+
+describe RailsJwtAuth::OmniauthsController, type: :request do
+  %w[ActiveRecord Mongoid].each do |orm|
+    context "when use #{orm}" do
+      before(:all) { initialize_orm(orm) }
+
+      let(:json) { JSON.parse(response.body) }
+      let(:user) { FactoryBot.create("#{orm.underscore}_user") }
+      let(:unconfirmed_user) { FactoryBot.create("#{orm.underscore}_unconfirmed_user") }
+      let(:locked_user) { FactoryBot.create("#{orm.underscore}_user", locked_at: 2.minutes.ago) }
+      let(:dummy_oauth_middleware) { :google_oauth2 }
+      let(:dummy_oauth_token) {{code: "1234567", redirect_uri: "postmessage"}}
+
+      describe 'POST #callback' do
+        context 'when all is ok' do
+          before do
+            allow("#{orm}User".constantize).to receive(:from_omniauth).and_return(user)
+            post oauth_callback_path(provider: dummy_oauth_middleware)
+          end
+
+          it 'returns 201 status code' do
+            expect(response.status).to eq(201)
+          end
+
+          it 'returns valid authentication token' do
+            jwt = json['session']['jwt']
+            token = RailsJwtAuth::JwtManager.decode(jwt)[0]['auth_token']
+            expect(token).to eq(user.reload.auth_tokens.last)
+          end
+        end
+
+        context 'when simultaneous sessions are 0' do
+          it 'returns id instead of token' do
+            allow("#{orm}User".constantize).to receive(:from_omniauth).and_return(user)
+            allow(RailsJwtAuth).to receive(:simultaneous_sessions).and_return(0)
+            post oauth_callback_path(provider: dummy_oauth_middleware)
+
+            jwt = json['session']['jwt']
+            payload = RailsJwtAuth::JwtManager.decode(jwt)[0]
+            expect(payload['auth_token']).to be_nil
+            expect(payload['id']).to eq(user.id.to_s)
+          end
+        end
+
+        context 'when not defined from_omniauth' do
+          before do
+            post oauth_callback_path(provider: dummy_oauth_middleware)
+          end
+
+          it 'returns 422 status code' do
+            expect(response.status).to eq(422)
+          end
+
+          it 'returns error message' do
+            expect(json['errors']['session'].first['error']).to eq 'not_found'
+          end
+        end
+
+        context 'when user is not confirmed' do
+          before do
+            allow("#{orm}User".constantize).to receive(:from_omniauth).and_return(unconfirmed_user)
+            post oauth_callback_path(provider: dummy_oauth_middleware)
+          end
+
+          it 'returns 422 status code' do
+            expect(response.status).to eq(422)
+          end
+
+          it 'returns error message' do
+            expect(json['errors']['email'].first['error']).to eq 'unconfirmed'
+          end
+        end
+
+        context 'when user is locked' do
+          before do
+            allow("#{orm}User".constantize).to receive(:from_omniauth).and_return(locked_user)
+            post oauth_callback_path(provider: dummy_oauth_middleware)
+          end
+
+          it 'returns 422 status code' do
+            expect(response.status).to eq(422)
+          end
+
+          it 'returns error message' do
+            expect(json['errors']['email'].first['error']).to eq 'locked'
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/dummy/app/models/active_record_user.rb
+++ b/spec/dummy/app/models/active_record_user.rb
@@ -5,10 +5,14 @@ class ActiveRecordUser < ApplicationRecord
   include RailsJwtAuth::Trackable
   include RailsJwtAuth::Invitable
   include RailsJwtAuth::Lockable
+  include RailsJwtAuth::Omniauthable
 
   attr_accessor :email_confirmation
 
   validates :email, presence: true,
                     uniqueness: true,
                     format: /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\z/i
+
+  def self.from_omniauth(hash)
+  end
 end

--- a/spec/dummy/app/models/mongoid_user.rb
+++ b/spec/dummy/app/models/mongoid_user.rb
@@ -6,6 +6,7 @@ class MongoidUser
   include RailsJwtAuth::Trackable
   include RailsJwtAuth::Invitable
   include RailsJwtAuth::Lockable
+  include RailsJwtAuth::Omniauthable
 
   attr_accessor :email_confirmation
 
@@ -15,4 +16,7 @@ class MongoidUser
   validates :email, presence: true,
                     uniqueness: true,
                     format: /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\z/i
+
+  def self.from_omniauth(hash)
+  end
 end

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -12,4 +12,5 @@ Rails.application.routes.draw do
   resources :reset_passwords, controller: 'rails_jwt_auth/reset_passwords', only: [:show, :create, :update]
   resources :invitations, controller: 'rails_jwt_auth/invitations', only: [:show, :create, :update]
   resources :unlock_accounts, controller: 'rails_jwt_auth/unlock_accounts', only: %i[update]
+  post '/auth/:provider/callback', to: 'rails_jwt_auth/omniauths#callback', as: 'oauth_callback'
 end

--- a/spec/lib/omniauth_manager_spec.rb
+++ b/spec/lib/omniauth_manager_spec.rb
@@ -1,0 +1,47 @@
+require 'rails_helper'
+require 'omniauth'
+
+require 'rails_jwt_auth/session'
+
+module RailsJwtAuth
+  describe OmniauthManager do
+    let(:dummy_provider) {:dummy}
+    let(:args) do
+      [
+        'key',
+        {name: :strategy_name}
+      ]
+    end
+    let(:strategy_class) {DummyStrategy}
+
+    class DummyStrategy
+      attr_accessor :default_options
+    end
+
+    context '#initialize' do
+      it 'create instance without strategies' do
+        instance = described_class.new(dummy_provider, args)
+        expect(instance.args).to eql args
+        expect(instance.options).to eql args[1]
+        expect(instance.provider).to eql dummy_provider
+        expect(instance.strategy_name).to eql :strategy_name
+      end
+    end
+
+    context '#strategy_class' do
+      it 'return strategy when register' do
+        strategy = strategy_class.new
+        strategy.default_options = {name: :strategy_name}
+        ::OmniAuth.strategies << strategy
+        instance = described_class.new(dummy_provider, args)
+        expect(instance.strategy_class).to eql strategy
+      end
+
+      it 'not return nothing when not strategy registered' do
+        allow(::OmniAuth).to receive(:strategies).and_return []
+        instance = described_class.new(dummy_provider, args)
+        expect(instance.strategy_class).to be_nil
+      end
+    end
+  end
+end

--- a/spec/lib/omniauth_session_spec.rb
+++ b/spec/lib/omniauth_session_spec.rb
@@ -1,0 +1,81 @@
+require 'rails_helper'
+
+require 'rails_jwt_auth/omniauth_session'
+
+module RailsJwtAuth
+  describe OmniauthSession do
+    %w[ActiveRecord Mongoid].each do |orm|
+      context "when use #{orm}" do
+        before(:all) { initialize_orm(orm) }
+
+        let(:pass) { '12345678' }
+        let(:user) { FactoryBot.create("#{orm.underscore}_user", password: pass) }
+        let(:unconfirmed_user) {
+          FactoryBot.create("#{orm.underscore}_unconfirmed_user", password: pass)
+        }
+
+        describe '#initialize' do
+          it 'does not fail when pass empty user' do
+            expect { OmniauthSession.new(nil) }.not_to raise_exception
+          end
+        end
+
+        describe '#valid?' do
+          it 'returns true when user is valid' do
+            session = OmniauthSession.new(user)
+            expect(session.valid?).to be_truthy
+          end
+
+          it 'returns false when user is invalid' do
+            session = OmniauthSession.new(nil)
+            expect(session.valid?).to be_falsey
+          end
+
+          it 'validates user' do
+            session = OmniauthSession.new(nil)
+            expect(session.valid?).to be_falsey
+            expect(get_record_error(session, :session)).to eq(:not_found)
+          end
+
+          it 'validates user is unconfirmed' do
+            session = OmniauthSession.new(unconfirmed_user)
+            expect(session.valid?).to be_falsey
+            expect(get_record_error(session, :email)).to eq(:unconfirmed)
+          end
+
+          it 'validates user is not locked' do
+            user.lock_access
+            session = OmniauthSession.new user
+            expect(session.valid?).to be_falsey
+            expect(get_record_error(session, :email)).to eq(:locked)
+          end
+        end
+
+        describe '#generate!' do
+          it 'increase failed attemps' do
+            allow_any_instance_of(RailsJwtAuth::OmniauthSession).to(
+              receive(:valid?).and_return(false)
+            )
+            OmniauthSession.new(user).generate!
+            expect(user.reload.failed_attempts).to eq(1)
+          end
+
+          it 'unlock access when lock is expired' do
+            travel_to(Date.today - 30.days) { user.lock_access }
+            session = OmniauthSession.new(user)
+            expect(session.generate!).to be_truthy
+            expect(user.reload.locked_at).to be_nil
+          end
+
+          it 'resets recovery password' do
+            travel_to(Date.today - 30.days) { user.send_reset_password_instructions }
+            session = OmniauthSession.new user
+            expect(session.generate!).to be_truthy
+            expect(user.reload.reset_password_token).to be_nil
+            expect(user.reload.reset_password_sent_at).to be_nil
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/models/concerns/omniauthable_spec.rb
+++ b/spec/models/concerns/omniauthable_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+describe RailsJwtAuth::Omniauthable do
+  class DummyClass
+    include RailsJwtAuth::Omniauthable
+  end
+
+  describe '#methods' do
+    it 'check from_omniauth' do
+      klass = DummyClass
+      expect { klass.from_omniauth(:foo) }.to(
+          raise_exception RailsJwtAuth::Omniauthable::NotImplementedMethod
+      )
+      klass.define_singleton_method(:from_omniauth) { |auth| auth }
+      expect(klass.from_omniauth(:foo)).to eql :foo
+    end
+  end
+end


### PR DESCRIPTION
## Omniauth module

This module allows you to automatize sessions for OAuth providers. It is based on Devise Omniauth's work.
Instructions have been added to README.

Providers can be created or used by [omniauth](https://github.com/omniauth/omniauth). These have to be added to the config of RailsJwtAuth. The option 'provider_ignores_state: true' is needed in each config to prevent CSRF problems. Providers are managed by OmniauthManager.

A module OmniauthSession has been created to manage sessions from OAuth. It uses code from Session that has been moved to a helper to reutilize in both classes.

This module needs a temporal token created by a library in the client of API. Process is explained in [google server-side flow](https://developers.google.com/identity/sign-in/web/server-side-flow)
